### PR TITLE
Ohai new config syntax

### DIFF
--- a/files/default/plugins/alternatives.rb
+++ b/files/default/plugins/alternatives.rb
@@ -11,11 +11,16 @@ begin
         alternative_name = line.scan( /[ ]*([^ ]+)/).first.first
         
         # Get information about one alternative
-        stdin, stdout, stderr, wait_thr = Open3.popen3('update-alternatives', '--display', alternative_name)
-        data = stdout.gets(nil)
-        stdout.close
-        stderr.gets(nil)
-        stderr.close
+        if $ohai_new_config_syntax
+          data = shell_out('update-alternatives', '--display', alternative_name).stdout
+        else
+          stdin, stdout, stderr, wait_thr = Open3.popen3('update-alternatives', '--display', alternative_name)
+          data = stdout.gets(nil)
+          stdout.close
+          stderr.gets(nil)
+          stderr.close
+        end
+        Chef::Log.debug("alternatives.rb: data = #{data}")
         
         # parse the information
         current_opt = 'UNKNOWN'

--- a/files/default/plugins/x-session-manager.rb
+++ b/files/default/plugins/x-session-manager.rb
@@ -7,9 +7,16 @@ end
 
 
 begin
-  desktop_session from("readlink /etc/alternatives/x-session-manager  | xargs basename")
+  if $ohai_new_config_syntax
+    desktop_session = shell_out("readlink /etc/alternatives/x-session-manager  | xargs basename")
+  else
+    desktop_session = Mixlib::ShellOut.new("readlink /etc/alternatives/x-session-manager  | xargs basename")
+    desktop_session.run_command
+  end
+  Chef::Log.debug("x-session-manager.rb: desktop_session = #{desktop_session.stdout}")
+
 rescue Exception => e
   puts e.message
 end
 
-ohai_gecos['desktop_session'] = desktop_session
+ohai_gecos['desktop_session'] = desktop_session.stdout

--- a/files/default/plugins7/alternatives.rb
+++ b/files/default/plugins7/alternatives.rb
@@ -14,11 +14,16 @@ Ohai.plugin(:Alternatives) do
                 alternative_name = line.scan( /[ ]*([^ ]+)/).first.first
                 
                 # Get information about one alternative
-                stdin, stdout, stderr, wait_thr = Open3.popen3('update-alternatives', '--display', alternative_name)
-                data = stdout.gets(nil)
-                stdout.close
-                stderr.gets(nil)
-                stderr.close
+                if $ohai_new_config_syntax
+                  data = shell_out('update-alternatives', '--display', alternative_name).stdout
+                else
+                  stdin, stdout, stderr, wait_thr = Open3.popen3('update-alternatives', '--display', alternative_name)
+                  data = stdout.gets(nil)
+                  stdout.close
+                  stderr.gets(nil)
+                  stderr.close
+                end
+                Chef::Log.debug("alternatives.rb: data = #{data}")
                 
                 # parse the information
                 current_opt = 'UNKNOWN'

--- a/files/default/plugins7/x-session-manager.rb
+++ b/files/default/plugins7/x-session-manager.rb
@@ -8,14 +8,19 @@ Ohai.plugin(:XSessionManager) do
           ohai_gecos Mash.new
         end
 
-
         begin
-          desktop_session from("readlink /etc/alternatives/x-session-manager  | xargs basename")
+          if $ohai_new_config_syntax
+            desktop_session=shell_out("readlink /etc/alternatives/x-session-manager  | xargs basename")
+          else
+            desktop_session = Mixlib::ShellOut.new("readlink /etc/alternatives/x-session-manager  | xargs basename")
+            desktop_session.run_command
+          end
+          Chef::Log.debug("x-session-manager.rb: desktop_session = #{desktop_session.stdout}")
         rescue Exception => e
           puts e.message
         end
 
-        ohai_gecos['desktop_session'] = desktop_session
+        ohai_gecos['desktop_session'] = desktop_session.stdout
 
     end
 end


### PR DESCRIPTION
Supress deprecated errors in chef client execution (Ohai >= 8.6.0). Backward compatible (V2, V3)

- Ohai::Config[:plugin_path] is set. Ohai::Config[:plugin_path] is deprecated and will be removed in future releases of ohai. Use ohai.plugin_path in your configuration file to configure :plugin_path for ohai.
- Ohai::Mixin::Command  run_command is deprecated and will be removed in Ohai 9.0.0
- Ohai::Mixin::Command popen4 is deprecated and will be removed in Ohai 9.0.0



