### PR TITLE
Add chef-client cookbook dependence

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,6 +6,8 @@ description      "Distributes a directory of custom ohai plugins"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.10.0"
 
+depends "chef-client"
+
 recipe "ohai::default", "Distributes a directory of custom ohai plugins"
 
 attribute "ohai/plugin_path",


### PR DESCRIPTION
chef-client cookbook dependence moved from gecos-workstation-management-cookbook